### PR TITLE
Fix/count defeated enemies

### DIFF
--- a/disasm/code/gameflow/battle/ai/aiengine_1.asm
+++ b/disasm/code/gameflow/battle/ai/aiengine_1.asm
@@ -72,7 +72,7 @@ StartAiControl:
                 
                 bsr.w   CountDefeatedEnemies
                 cmp.b   d1,d0
-                ble.s   @NonSwarmAi     ; if d1 < d0, process normally, else skip turn
+                ble.s   @NonSwarmAi     ; if d1 >= d0, process normally, else skip turn
                 lea     (CURRENT_BATTLEACTION).l,a0
                 move.w  #BATTLEACTION_STAY,(a0)
                 lea     ((BATTLE_ENTITY_MOVE_STRING-$1000000)).w,a0

--- a/disasm/code/gameflow/battle/ai/aiengine_1.asm
+++ b/disasm/code/gameflow/battle/ai/aiengine_1.asm
@@ -205,7 +205,11 @@ StartAiControl:
 CountDefeatedEnemies:
                 
                 movem.l d0/d2-a6,-(sp)
-                move.w  #BATTLESPRITESET_SUBSECTION_ALLIES,d1
+                if (FIX_COUNT_DEFEATED_ENEMIES=1)
+            	    move.w  #BATTLESPRITESET_SUBSECTION_ENEMIES,d1 ;properly checks all monsters in the battle
+            	else
+            	    move.w  #BATTLESPRITESET_SUBSECTION_ALLIES,d1 ;incorrectly limits to the counting of dead monsters to the ally battle slot count
+            	endif
                 jsr     j_GetBattleSpritesetSubsection
                 move.w  d1,d2
                 subi.w  #2,d2

--- a/disasm/code/gameflow/battle/ai/aiengine_1.asm
+++ b/disasm/code/gameflow/battle/ai/aiengine_1.asm
@@ -72,7 +72,7 @@ StartAiControl:
                 
                 bsr.w   CountDefeatedEnemies
                 cmp.b   d1,d0
-                ble.s   @NonSwarmAi     ; if d1 >= d0, process normally, else skip turn
+                ble.s   @NonSwarmAi     ; if d1 < d0, process normally, else skip turn
                 lea     (CURRENT_BATTLEACTION).l,a0
                 move.w  #BATTLEACTION_STAY,(a0)
                 lea     ((BATTLE_ENTITY_MOVE_STRING-$1000000)).w,a0

--- a/disasm/sf2patches.asm
+++ b/disasm/sf2patches.asm
@@ -1,0 +1,5 @@
+
+; 0 = OFF, 1 = ON
+
+; Fixes
+FIX_COUNT_DEFEATED_ENEMIES:         equ 1       ; Fixes the death counter that impacts "swarm AI" for battles 16, 20, 21. In vanilla, does not impact battles 16, 20, but makes 21 more aggressive.


### PR DESCRIPTION
Fixes the glitch in the original game where the subroutine CountDefeatedEnemies checks for the number of ally slots available in battle rather than the number of monster slots. This has no effect in the original game for battles 16 and 20 because the number of ally and monster slots are identical. But it makes battle 21 (Chess) much less aggressive than originally designed.