### PR TITLE
Feature/add battlescene musics

### DIFF
--- a/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
+++ b/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
@@ -334,14 +334,14 @@ LoadBattlesceneMusicIndex:
 					beq.s   @SpecialMusicUnpromoted
 					
 					; Promoted
-					lea     table_AllyBattlesceneMusics_Promoted, a0
+					lea		table_AllyBattlesceneMusics_Promoted(pc),a0
 					bra.s	@SpecialMusicTest
 @SpecialMusicUnpromoted:
-					lea     table_AllyBattlesceneMusics_Unpromoted, a0
+					lea		table_AllyBattlesceneMusics_Unpromoted(pc),a0
 @SpecialMusicTest:
-					add		d0, a0
+					adda.w  d0,a0
                     move.b  (a0),d3
-					cmpi.b  #-1,d3
+					cmpi.b  #0,d3
                     beq.s   @SpecialMusicDisabled ; No special music defined for this Force member
                     bra	    @LoadIndex ; Submit the special music
 @SpecialMusicDisabled:

--- a/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
+++ b/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
@@ -321,8 +321,31 @@ LoadBattlesceneMusicIndex:
 				
                 movem.l d1-d2/a0,-(sp)
                 tst.b   d0
-                bmi.s   @Enemy
+                bmi     @Enemy
 
+				if (ENABLE_ALLY_SPECIAL_MUSIC=1)
+                    ; Check if battle action is an item and skip special music if so
+                    move.w  ((CURRENT_BATTLEACTION-$1000000)).w,d2
+                    cmpi.w  #BATTLEACTION_USE_ITEM,d2
+                    beq.s   @SpecialMusicDisabled
+					
+					; Verify which table to use
+					jsr     GetClassType
+					beq.s   @SpecialMusicUnpromoted
+					
+					; Promoted
+					lea     table_AllyBattlesceneMusics_Promoted, a0
+					bra.s	@SpecialMusicTest
+@SpecialMusicUnpromoted:
+					lea     table_AllyBattlesceneMusics_Unpromoted, a0
+@SpecialMusicTest:
+					add		d0, a0
+                    move.b  (a0),d3
+					cmpi.b  #-1,d3
+                    beq.s   @SpecialMusicDisabled ; No special music defined for this Force member
+                    bra	    @LoadIndex ; Submit the special music
+@SpecialMusicDisabled:
+				endif
                 if (ENABLE_ALLY_SUPPORT_MUSIC=1)
                     ; Ignore muddled Force members for support music check
                     jsr     GetStatusEffects
@@ -417,7 +440,9 @@ LoadBattlesceneMusicIndex:
                     bra.s   @LoadIndex
 				endif
 
-@LoadIndex:     move.b  d3,((BATTLESCENE_MUSIC_INDEX-$1000000)).w
+				nop ; To avoid the assembler being angry with trivial branch when all patches are disabled
+@LoadIndex:
+				move.b  d3,((BATTLESCENE_MUSIC_INDEX-$1000000)).w
                 movem.l (sp)+,d1-d2/a0
                 rts
 

--- a/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
+++ b/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
@@ -370,13 +370,53 @@ LoadBattlesceneMusicIndex:
                     bra.s   @LoadIndex
                 endif
 
-@Enemy:         move.b  #MUSIC_ENEMY_ATTACK,d3
+@Enemy:			; Check for special music assigned to this monster
                 lea     table_EnemyBattlesceneMusics(pc), a0
                 jsr     GetEnemy
                 moveq   #1,d2
                 jsr     (FindSpecialPropertyBytesAddressForObject).w
-                bcs.s   @LoadIndex
-                move.b  (a0),d3
+                bcs.s   @EnemyNotSpecial ; Special music not found: go to default enemy music selection logic
+                move.b  (a0),d3 ; Special music found
+                bra.s   @LoadIndex ; Load the special music
+@EnemyNotSpecial:
+                if (ENABLE_ENEMY_SUPPORT_MUSIC=1)
+                    ; Ignore muddled monsters for support music check
+                    jsr     GetStatusEffects
+                    move.w  d1,statusEffects(a6)
+                    andi.w  #STATUSEFFECT_MUDDLE,d1
+                    bne.s   @EnemySupportMusicDisabled
+
+                    ; Check if there is a Force member target
+                    clr.w   d2
+                    move.b  ((BATTLESCENE_FIRST_ALLY-$1000000)).w,d2
+                    cmpi.b  #-1,d2
+                    beq.s   @EnemySupportMusic ; No Force member target in the battlescene and not muddled: go ahead with support music
+@EnemySupportMusicDisabled:
+                endif
+                if (ENABLE_ENEMY_SPELL_MUSIC=1)
+                    ; Check if battle action is a spell or item
+                    move.w  ((CURRENT_BATTLEACTION-$1000000)).w,d2
+                    cmpi.w  #BATTLEACTION_CAST_SPELL,d2
+                    beq.s   @EnemySpellOrItemMusic
+                    cmpi.w  #BATTLEACTION_USE_ITEM,d2
+                    beq.s   @EnemySpellOrItemMusic
+                endif
+				
+				; Use normal monster music we all know and love
+				move.b  #MUSIC_ENEMY_ATTACK,d3
+                bra.s   @LoadIndex
+				
+                if (ENABLE_ENEMY_SUPPORT_MUSIC=1)
+@EnemySupportMusic:
+                    move.b  #ENEMY_SUPPORT_MUSIC,d3
+                    bra.s   @LoadIndex
+				endif
+                if (ENABLE_ENEMY_SPELL_MUSIC=1)
+@EnemySpellOrItemMusic:
+                    move.b  #ENEMY_SPELL_MUSIC,d3
+                    bra.s   @LoadIndex
+				endif
+
 @LoadIndex:     move.b  d3,((BATTLESCENE_MUSIC_INDEX-$1000000)).w
                 movem.l (sp)+,d1-d2/a0
                 rts

--- a/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
+++ b/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
@@ -318,15 +318,57 @@ DetermineRandomAttackSpell:
 ; Load battlescene music index for combatant d0.w
 
 LoadBattlesceneMusicIndex:
-                
                 movem.l d1-d2/a0,-(sp)
                 tst.b   d0
                 bmi.s   @Enemy
+
+                if (ENABLE_ALLY_SUPPORT_MUSIC=1)
+                    ; Ignore muddled Force members for support music check
+                    jsr     GetStatusEffects
+                    move.w  d1,statusEffects(a6)
+                    andi.w  #STATUSEFFECT_MUDDLE,d1
+                    bne.s   @SupportMusicDisabled
+
+                    ; Check if there is a monster target
+                    clr.w   d2
+                    move.b  ((BATTLESCENE_FIRST_ENEMY-$1000000)).w,d2
+                    cmpi.b  #-1,d2
+                    beq.s   @SupportMusic ; No monster target in the battlescene and not muddled: go ahead with support music
+@SupportMusicDisabled:
+                endif
+
+                if (ENABLE_ALLY_SPELL_MUSIC=1)
+                    ; Check if battle action is a spell or item
+                    move.w  ((CURRENT_BATTLEACTION-$1000000)).w,d2
+                    cmpi.w  #BATTLEACTION_CAST_SPELL,d2
+                    beq.s   @SpellOrItemMusic
+                    cmpi.w  #BATTLEACTION_USE_ITEM,d2
+                    beq.s   @SpellOrItemMusic
+                endif
+
                 move.b  #MUSIC_ATTACK,d3
                 jsr     GetClassType
                 beq.s   @LoadIndex
                 move.b  #MUSIC_PROMOTED_ATTACK,d3
                 bra.s   @LoadIndex
+
+                if (ENABLE_ALLY_SUPPORT_MUSIC=1)
+@SupportMusic:
+                    move.b  #ALLY_SUPPORT_MUSIC,d3
+                    jsr     GetClassType
+                    beq.s   @LoadIndex
+                    move.b  #ALLY_SUPPORT_PROMOTED_MUSIC,d3
+                    bra.s   @LoadIndex
+                endif
+                if (ENABLE_ALLY_SPELL_MUSIC=1)
+@SpellOrItemMusic:
+                    move.b  #ALLY_SPELL_MUSIC,d3
+                    jsr     GetClassType
+                    beq.s   @LoadIndex
+                    move.b  #ALLY_SPELL_PROMOTED_MUSIC,d3
+                    bra.s   @LoadIndex
+                endif
+
 @Enemy:         move.b  #MUSIC_ENEMY_ATTACK,d3
                 lea     table_EnemyBattlesceneMusics(pc), a0
                 jsr     GetEnemy

--- a/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
+++ b/disasm/code/gameflow/battle/battlefunctions/executeindividualturn-standard.asm
@@ -318,6 +318,7 @@ DetermineRandomAttackSpell:
 ; Load battlescene music index for combatant d0.w
 
 LoadBattlesceneMusicIndex:
+				
                 movem.l d1-d2/a0,-(sp)
                 tst.b   d0
                 bmi.s   @Enemy

--- a/disasm/code/gameflow/battle/battleloop-standard.asm
+++ b/disasm/code/gameflow/battle/battleloop-standard.asm
@@ -21,7 +21,7 @@ BattleLoop:
                 dbf     d7,@ClearAiMemory_Loop
                 
                 clearSavedByte PLAYER_TYPE
-            if (MUSIC_RESUMING&RESUME_BATTLESCENE_MUSIC=1)
+            if (MUSIC_RESUMING=1)
                 activateMusicResuming
             endif
                 

--- a/disasm/code/gameflow/battle/battleloop_1.asm
+++ b/disasm/code/gameflow/battle/battleloop_1.asm
@@ -11,9 +11,6 @@
 BattleLoop:
                 
                 clearSavedByte PLAYER_TYPE
-            if (MUSIC_RESUMING&RESUME_BATTLESCENE_MUSIC=1)
-                activateMusicResuming
-            endif
             if (STANDARD_BUILD&ORIGINAL_TAROS_INVULNERABILITY=1)
                 ; Make sure to clear the "invulnerable enemy" flag when initializing a new battle
                 clrFlg  112             ; Currently attacking Taros with Achilles Sword

--- a/disasm/code/gameflow/battle/battlemusic-standard.asm
+++ b/disasm/code/gameflow/battle/battlemusic-standard.asm
@@ -13,7 +13,7 @@ PlayMapMusic:
                 compareToSavedByte #NOT_CURRENTLY_IN_BATTLE, CURRENT_BATTLE
                 beq.s   @Continue
                 
-            if (MUSIC_RESUMING&RESUME_BATTLEFIELD_MUSIC_ONLY=1)
+            if (MUSIC_RESUMING=1)
                 activateMusicResuming
             endif
                 lea     table_ExplorationToBattleMusics(pc), a0

--- a/disasm/code/gameflow/battle/battlemusic-standard.asm
+++ b/disasm/code/gameflow/battle/battlemusic-standard.asm
@@ -7,15 +7,27 @@
 
 PlayMapMusic:
                 
-                movem.l d0-d2/a0,-(sp)
+                movem.l d0,-(sp)
+				jsr		GetMapMusic		; d0 = current map music
+            if (MUSIC_RESUMING=1)
+                activateMusicResuming
+            endif
+                sndCom  SOUND_COMMAND_GET_D0_PARAMETER
+                movem.l (sp)+,d0
+                rts
+
+    ; End of function PlayMapMusic
+
+; =============== S U B R O U T I N E =======================================
+
+
+GetMapMusic:	
+                movem.l d1-d2/a0,-(sp)
                 clr.w   d0
                 move.b  ((MAP_AREA_MUSIC_INDEX-$1000000)).w,d0
                 compareToSavedByte #NOT_CURRENTLY_IN_BATTLE, CURRENT_BATTLE
                 beq.s   @Continue
                 
-            if (MUSIC_RESUMING=1)
-                activateMusicResuming
-            endif
                 lea     table_ExplorationToBattleMusics(pc), a0
                 move.w  d0,d1
                 moveq   #1,d2
@@ -24,9 +36,37 @@ PlayMapMusic:
                 move.b  (a0),d0
                 
 @Continue:      
-                sndCom  SOUND_COMMAND_GET_D0_PARAMETER
-                movem.l (sp)+,d0-d2/a0
-                rts
+                movem.l (sp)+,d1-d2/a0
+                rts						; d0 = current map music
 
-    ; End of function PlayMapMusic
 
+    ; End of function GetMapMusic
+	
+	
+; =============== S U B R O U T I N E =======================================
+
+
+ShouldPlayBattlesceneMusic:						
+			if (ENABLE_UNINTERRUPTIBLE_MUSIC=1)
+				movem.l a0,-(sp)
+				jsr		GetMapMusic		; d0 = current map music
+				lea		table_UninterruptibleMusics(pc),a0
+@TestNextUninterruptibleTableIndex:
+				cmp.b	(a0),d0
+				beq.s	@DoNotPlayMusic ; Hit music number in table -> do not play battlescene music
+				cmp.b	#0,(a0)+
+				bne.s	@TestNextUninterruptibleTableIndex ; Keep browsing the table
+				move.b	#1,d0	; End of table reached -> play battlescene music
+				bra.s	@Return
+@DoNotPlayMusic:
+				move.b	#0,d0
+@Return
+                movem.l	(sp)+,a0
+				rts
+			else
+				move.b	#1,d0
+				rts
+			endif
+
+
+    ; End of function ShouldPlayBattlesceneMusic		; d0 = 0 don't play, 1 play

--- a/disasm/code/gameflow/battle/battlescenes/battlesceneengine_0.asm
+++ b/disasm/code/gameflow/battle/battlescenes/battlesceneengine_0.asm
@@ -1725,7 +1725,18 @@ EndBattlescene:
                 dbf     d0,@WaitForInput
 byte_19266:
                 
+			if (STANDARD_BUILD&ENABLE_UNINTERRUPTIBLE_MUSIC=1)
+				; Verify if we should fade out music
+                move.w  d0,-(sp)
+				jsr		ShouldPlayBattlesceneMusic		; d0 = 0 don't play, 1 play
+				cmp.b	#0,d0
+				beq.s	@SkipMusicFadeOut
                 sndCom  SOUND_COMMAND_FADE_OUT
+@SkipMusicFadeOut:
+                move.w  (sp)+,d0
+			else
+                sndCom  SOUND_COMMAND_FADE_OUT
+			endif
                 move.w  ((BATTLESCENE_ALLY-$1000000)).w,d0
                 cmpi.w  #-1,d0
                 beq.s   @Enemy

--- a/disasm/code/gameflow/battle/battlescenes/initializebattlescene-standard.asm
+++ b/disasm/code/gameflow/battle/battlescenes/initializebattlescene-standard.asm
@@ -315,11 +315,19 @@ alt_InitializeBattlescene:
                 
                 jsr     (WaitForVInt).w
                 bsr.w   FadeInFromBlackIntoBattlescene
-            if (MUSIC_RESUMING&RESUME_BATTLEFIELD_MUSIC_ONLY=1)
-                deactivateMusicResuming
-            endif
                 clr.w   d0
                 move.b  (BATTLESCENE_MUSIC_INDEX).l,d0
+            if (MUSIC_RESUMING=1)
+				lea		table_ResumingBattlesceneMusics(pc),a0
+@TestNextTableIndex:
+				cmp.b	(a0),d0
+				beq.s	@KeepMusicResuming ; Hit music number in table -> resume
+				cmp.b	#0,(a0)+
+				bne.s	@TestNextTableIndex ; Keep browsing the table
+                deactivateMusicResuming ; End of table reached -> no resume (note: d0 is unchanged by snd cmd)
+@KeepMusicResuming:
+            endif
+			
                 sndCom  SOUND_COMMAND_GET_D0_PARAMETER
                 moveq   #21,d0
 @MoveActorsToPosition_Loop:

--- a/disasm/code/gameflow/battle/battlescenes/initializebattlescene-standard.asm
+++ b/disasm/code/gameflow/battle/battlescenes/initializebattlescene-standard.asm
@@ -44,8 +44,16 @@ GetAllyGraphicsInformation:
 InitializeBattlescene:
                 
                 bsr.w   FadeOutToBlackForBattlescene
+				
+				; Verify if we should fade out music
+                move.w  d0,-(sp)
+				jsr		ShouldPlayBattlesceneMusic		; d0 = 0 don't play, 1 play
+				cmp.b	#0,d0
+				beq.s	@SkipMusicFadeOut
                 sndCom  SOUND_COMMAND_FADE_OUT
-                
+@SkipMusicFadeOut:
+                move.w  (sp)+,d0
+				
                 ; Clear battlescene data table in RAM
                 lea     ((BATTLESCENE_BACKGROUND_MODIFICATION_POINTER-$1000000)).w,a0
                 move.l  #((BATTLESCENE_DATA_END-BATTLESCENE_BACKGROUND_MODIFICATION_POINTER)/4)-1,d2 ; battle scene data longwords counter
@@ -315,6 +323,11 @@ alt_InitializeBattlescene:
                 
                 jsr     (WaitForVInt).w
                 bsr.w   FadeInFromBlackIntoBattlescene
+				
+				jsr		ShouldPlayBattlesceneMusic		; d0 = 0 don't play, 1 play
+				cmp.b	#0,d0
+				beq.s	@SkipPlayMusic
+
                 clr.w   d0
                 move.b  (BATTLESCENE_MUSIC_INDEX).l,d0
             if (MUSIC_RESUMING=1)
@@ -329,6 +342,7 @@ alt_InitializeBattlescene:
             endif
 			
                 sndCom  SOUND_COMMAND_GET_D0_PARAMETER
+@SkipPlayMusic:
                 moveq   #21,d0
 @MoveActorsToPosition_Loop:
                 

--- a/disasm/data/resumingbattlescenemusics-standard.asm
+++ b/disasm/data/resumingbattlescenemusics-standard.asm
@@ -5,6 +5,5 @@
 ; Tip: add all musics with long, rewarding buildups and exclude musics that are intense from the start.
 
 table_ResumingBattlesceneMusics:
-	dc.b	MUSIC_TOWN
-	dc.b	MUSIC_ENEMY_ATTACK
+	;dc.b	MUSIC_ENEMY_ATTACK
 	dc.b	0	; End

--- a/disasm/data/resumingbattlescenemusics-standard.asm
+++ b/disasm/data/resumingbattlescenemusics-standard.asm
@@ -1,0 +1,10 @@
+; Specify here the list of musics that should enable resuming when they are used in battlescenes.
+; Keep in mind that music resuming will only work if consecutive battlescenes use the same music. Otherwise, the music will play from the beginning.
+; The list must end with a zero value.
+
+; Tip: add all musics with long, rewarding buildups and exclude musics that are intense from the start.
+
+table_ResumingBattlesceneMusics:
+	dc.b	MUSIC_TOWN
+	dc.b	MUSIC_ENEMY_ATTACK
+	dc.b	0	; End

--- a/disasm/data/stats/allies/allybattlescenemusics-standard.asm
+++ b/disasm/data/stats/allies/allybattlescenemusics-standard.asm
@@ -10,7 +10,7 @@ table_AllyBattlesceneMusics_Unpromoted:
 	dc.b	0	; Ally 4 - KAZIN
 	dc.b	0	; Ally 5 - SLADE
 	dc.b	0	; Ally 6 - KIWI
-	dc.b	MUSIC_BOSS_ATTACK	; Ally 7 - PETER
+	dc.b	MUSIC_BOSS_ATTACK	; Ally 7 - PETER	(I'm sure you understand the joke here ;))
 	dc.b	0	; Ally 8 - MAY
 	dc.b	0	; Ally 9 - GERHALT
 	dc.b	0	; Ally 10 - LUKE

--- a/disasm/data/stats/allies/allybattlescenemusics-standard.asm
+++ b/disasm/data/stats/allies/allybattlescenemusics-standard.asm
@@ -1,71 +1,71 @@
-; You can set here battlescene music override for specific player characters (-1 to have no override).
+; You can set here battlescene music override for specific player characters (0 to have no override).
 ; Per-character music override will play if the character DOESN'T use an item, it will play for standard attacks and spells.
 ; Per-character music override has the highest priority if you also use support/spell music patches.
 
 table_AllyBattlesceneMusics_Unpromoted:
-	dc.b	MUSIC_TOWN	; Ally 0
-	dc.b	-1	; Ally 1
-	dc.b	-1	; Ally 2
-	dc.b	-1	; Ally 3
-	dc.b	-1	; Ally 4
-	dc.b	-1	; Ally 5
-	dc.b	-1	; Ally 6
-	dc.b	-1	; Ally 7
-	dc.b	-1	; Ally 8
-	dc.b	-1	; Ally 9
-	dc.b	-1	; Ally 10
-	dc.b	-1	; Ally 11
-	dc.b	-1	; Ally 12
-	dc.b	-1	; Ally 13
-	dc.b	-1	; Ally 14
-	dc.b	-1	; Ally 15
-	dc.b	-1	; Ally 16
-	dc.b	-1	; Ally 17
-	dc.b	-1	; Ally 18
-	dc.b	-1	; Ally 19
-	dc.b	-1	; Ally 20
-	dc.b	-1	; Ally 21
-	dc.b	-1	; Ally 22
-	dc.b	-1	; Ally 23
-	dc.b	-1	; Ally 24
-	dc.b	-1	; Ally 25
-	dc.b	-1	; Ally 26
-	dc.b	-1	; Ally 27
-	dc.b	-1	; Ally 28
-	dc.b	-1	; Ally 29
-	dc.b	-1	; Ally 30
-	dc.b	-1	; Ally 31
+	dc.b	MUSIC_TOWN	; Ally 0 - BOWIE
+	dc.b	0	; Ally 1 - SARAH
+	dc.b	0	; Ally 2 - CHESTER
+	dc.b	0	; Ally 3 - JAHA
+	dc.b	0	; Ally 4 - KAZIN
+	dc.b	0	; Ally 5 - SLADE
+	dc.b	0	; Ally 6 - KIWI
+	dc.b	MUSIC_BOSS_ATTACK	; Ally 7 - PETER
+	dc.b	0	; Ally 8 - MAY
+	dc.b	0	; Ally 9 - GERHALT
+	dc.b	0	; Ally 10 - LUKE
+	dc.b	0	; Ally 11 - ROHDE
+	dc.b	0	; Ally 12 - RICK
+	dc.b	0	; Ally 13 - ELRIC
+	dc.b	0	; Ally 14 - ERIC
+	dc.b	0	; Ally 15 - KARNA
+	dc.b	0	; Ally 16 - RANDOLF
+	dc.b	0	; Ally 17 - TYRIN
+	dc.b	0	; Ally 18 - JANET
+	dc.b	0	; Ally 19 - HIGINS
+	dc.b	0	; Ally 20 - SKREECH
+	dc.b	0	; Ally 21 - TAYA
+	dc.b	0	; Ally 22 - FRAYJA
+	dc.b	0	; Ally 23 - JARO
+	dc.b	0	; Ally 24 - GYAN
+	dc.b	0	; Ally 25 - SHEELA
+	dc.b	0	; Ally 26 - ZYNK
+	dc.b	0	; Ally 27 - CHAZ
+	dc.b	0	; Ally 28 - LEMON
+	dc.b	0	; Ally 29 - CLAUDE
+	dc.b	0	; Ally 30
+	dc.b	0	; Ally 31
 
 table_AllyBattlesceneMusics_Promoted:
-	dc.b	MUSIC_CASTLE	; Ally 0
-	dc.b	-1	; Ally 1
-	dc.b	-1	; Ally 2
-	dc.b	-1	; Ally 3
-	dc.b	-1	; Ally 4
-	dc.b	-1	; Ally 5
-	dc.b	-1	; Ally 6
-	dc.b	-1	; Ally 7
-	dc.b	-1	; Ally 8
-	dc.b	-1	; Ally 9
-	dc.b	-1	; Ally 10
-	dc.b	-1	; Ally 11
-	dc.b	-1	; Ally 12
-	dc.b	-1	; Ally 13
-	dc.b	-1	; Ally 14
-	dc.b	-1	; Ally 15
-	dc.b	-1	; Ally 16
-	dc.b	-1	; Ally 17
-	dc.b	-1	; Ally 18
-	dc.b	-1	; Ally 19
-	dc.b	-1	; Ally 20
-	dc.b	-1	; Ally 21
-	dc.b	-1	; Ally 22
-	dc.b	-1	; Ally 23
-	dc.b	-1	; Ally 24
-	dc.b	-1	; Ally 25
-	dc.b	-1	; Ally 26
-	dc.b	-1	; Ally 27
-	dc.b	-1	; Ally 28
-	dc.b	-1	; Ally 29
-	dc.b	-1	; Ally 30
-	dc.b	-1	; Ally 31
+	dc.b	MUSIC_CASTLE	; Ally 0 - BOWIE
+	dc.b	0	; Ally 1 - SARAH
+	dc.b	0	; Ally 2 - CHESTER
+	dc.b	0	; Ally 3 - JAHA
+	dc.b	0	; Ally 4 - KAZIN
+	dc.b	0	; Ally 5 - SLADE
+	dc.b	0	; Ally 6 - KIWI
+	dc.b	MUSIC_BOSS_ATTACK	; Ally 7 - PETER
+	dc.b	0	; Ally 8 - MAY
+	dc.b	0	; Ally 9 - GERHALT
+	dc.b	0	; Ally 10 - LUKE
+	dc.b	0	; Ally 11 - ROHDE
+	dc.b	0	; Ally 12 - RICK
+	dc.b	0	; Ally 13 - ELRIC
+	dc.b	0	; Ally 14 - ERIC
+	dc.b	0	; Ally 15 - KARNA
+	dc.b	0	; Ally 16 - RANDOLF
+	dc.b	0	; Ally 17 - TYRIN
+	dc.b	0	; Ally 18 - JANET
+	dc.b	0	; Ally 19 - HIGINS
+	dc.b	0	; Ally 20 - SKREECH
+	dc.b	0	; Ally 21 - TAYA
+	dc.b	0	; Ally 22 - FRAYJA
+	dc.b	0	; Ally 23 - JARO
+	dc.b	0	; Ally 24 - GYAN
+	dc.b	0	; Ally 25 - SHEELA
+	dc.b	0	; Ally 26 - ZYNK
+	dc.b	0	; Ally 27 - CHAZ
+	dc.b	0	; Ally 28 - LEMON
+	dc.b	0	; Ally 29 - CLAUDE
+	dc.b	0	; Ally 30
+	dc.b	0	; Ally 31

--- a/disasm/data/stats/allies/allybattlescenemusics-standard.asm
+++ b/disasm/data/stats/allies/allybattlescenemusics-standard.asm
@@ -1,0 +1,71 @@
+; You can set here battlescene music override for specific player characters (-1 to have no override).
+; Per-character music override will play if the character DOESN'T use an item, it will play for standard attacks and spells.
+; Per-character music override has the highest priority if you also use support/spell music patches.
+
+table_AllyBattlesceneMusics_Unpromoted:
+	dc.b	MUSIC_TOWN	; Ally 0
+	dc.b	-1	; Ally 1
+	dc.b	-1	; Ally 2
+	dc.b	-1	; Ally 3
+	dc.b	-1	; Ally 4
+	dc.b	-1	; Ally 5
+	dc.b	-1	; Ally 6
+	dc.b	-1	; Ally 7
+	dc.b	-1	; Ally 8
+	dc.b	-1	; Ally 9
+	dc.b	-1	; Ally 10
+	dc.b	-1	; Ally 11
+	dc.b	-1	; Ally 12
+	dc.b	-1	; Ally 13
+	dc.b	-1	; Ally 14
+	dc.b	-1	; Ally 15
+	dc.b	-1	; Ally 16
+	dc.b	-1	; Ally 17
+	dc.b	-1	; Ally 18
+	dc.b	-1	; Ally 19
+	dc.b	-1	; Ally 20
+	dc.b	-1	; Ally 21
+	dc.b	-1	; Ally 22
+	dc.b	-1	; Ally 23
+	dc.b	-1	; Ally 24
+	dc.b	-1	; Ally 25
+	dc.b	-1	; Ally 26
+	dc.b	-1	; Ally 27
+	dc.b	-1	; Ally 28
+	dc.b	-1	; Ally 29
+	dc.b	-1	; Ally 30
+	dc.b	-1	; Ally 31
+
+table_AllyBattlesceneMusics_Promoted:
+	dc.b	MUSIC_CASTLE	; Ally 0
+	dc.b	-1	; Ally 1
+	dc.b	-1	; Ally 2
+	dc.b	-1	; Ally 3
+	dc.b	-1	; Ally 4
+	dc.b	-1	; Ally 5
+	dc.b	-1	; Ally 6
+	dc.b	-1	; Ally 7
+	dc.b	-1	; Ally 8
+	dc.b	-1	; Ally 9
+	dc.b	-1	; Ally 10
+	dc.b	-1	; Ally 11
+	dc.b	-1	; Ally 12
+	dc.b	-1	; Ally 13
+	dc.b	-1	; Ally 14
+	dc.b	-1	; Ally 15
+	dc.b	-1	; Ally 16
+	dc.b	-1	; Ally 17
+	dc.b	-1	; Ally 18
+	dc.b	-1	; Ally 19
+	dc.b	-1	; Ally 20
+	dc.b	-1	; Ally 21
+	dc.b	-1	; Ally 22
+	dc.b	-1	; Ally 23
+	dc.b	-1	; Ally 24
+	dc.b	-1	; Ally 25
+	dc.b	-1	; Ally 26
+	dc.b	-1	; Ally 27
+	dc.b	-1	; Ally 28
+	dc.b	-1	; Ally 29
+	dc.b	-1	; Ally 30
+	dc.b	-1	; Ally 31

--- a/disasm/data/uninterruptiblemusics-standard.asm
+++ b/disasm/data/uninterruptiblemusics-standard.asm
@@ -1,0 +1,11 @@
+; Specify here the list of battle map musics that should keep playing during battlescenes.
+; The list must end with a zero value.
+
+; Tip: use this sparingly, keep it for major set pieces, such as sad battle musics after a character death or final battle music.
+
+table_UninterruptibleMusics:
+	;dc.b	MUSIC_SAD_THEME_1
+	;dc.b	MUSIC_SAD_THEME_2
+	;dc.b	MUSIC_SAD_THEME_3
+	dc.b	MUSIC_FINAL_BATTLE
+	dc.b	0	; End

--- a/disasm/layout/sf2-02-0x008000-0x010000.asm
+++ b/disasm/layout/sf2-02-0x008000-0x010000.asm
@@ -27,7 +27,10 @@
                 includeIfStandard "code\common\stats-standard\caravaninventory.asm"    ; Caravan inventory management functions
                 includeIfStandard "data\stats\allies\newgameallies-standard.asm"
                 includeIfStandard "data\stats\allies\allieswithbetterdouble-standard.asm"
-                
+            if (ENABLE_ALLY_SPECIAL_MUSIC=1)
+                includeIfStandard "data\stats\allies\allybattlescenemusics-standard.asm"	; Per-character battlescene music override
+            endif
+				
                 ; Stats engine
                 includeIfVanilla "code\common\stats\combatantstats_1.asm"    ; Read combatant stats
                 includeIfVanilla "code\common\stats\getcombatanttype.asm"    ; Combatant type getter function

--- a/disasm/layout/sf2-02-0x008000-0x010000.asm
+++ b/disasm/layout/sf2-02-0x008000-0x010000.asm
@@ -27,9 +27,6 @@
                 includeIfStandard "code\common\stats-standard\caravaninventory.asm"    ; Caravan inventory management functions
                 includeIfStandard "data\stats\allies\newgameallies-standard.asm"
                 includeIfStandard "data\stats\allies\allieswithbetterdouble-standard.asm"
-            if (ENABLE_ALLY_SPECIAL_MUSIC=1)
-                includeIfStandard "data\stats\allies\allybattlescenemusics-standard.asm"	; Per-character battlescene music override
-            endif
 				
                 ; Stats engine
                 includeIfVanilla "code\common\stats\combatantstats_1.asm"    ; Read combatant stats

--- a/disasm/layout/sf2-04-0x018000-0x020000.asm
+++ b/disasm/layout/sf2-04-0x018000-0x020000.asm
@@ -6,6 +6,10 @@
 
                 include "code\common\tech\jumpinterfaces\s04_jumpinterface.asm"    ; Game Section 04 Jump Interface
                 includeIfStandard "code\gameflow\battle\battlescenes\initializebattlescene-standard.asm"    ; Battlescene engine
+			if (MUSIC_RESUMING=1)
+				includeIfStandard "data\resumingbattlescenemusics-standard.asm"
+                alignIfStandard
+			endif
                 includeIfVanilla "code\gameflow\battle\battlescenes\nullsub_18010.asm"    ; Battlescene engine
                 includeIfVanilla "code\gameflow\battle\battlescenes\initializebattlescene.asm"    ; Battlescene engine
                 include "code\gameflow\battle\battlescenes\battlesceneengine_0.asm"    ; Battlescene engine

--- a/disasm/layout/sf2-05-0x020000-0x028000.asm
+++ b/disasm/layout/sf2-05-0x020000-0x028000.asm
@@ -47,6 +47,9 @@
                 includeIfStandard "code\gameflow\battle\battleloop-standard\getegresspositionforbattle.asm"
                 
                 ; Battle functions
+            if (ENABLE_ALLY_SPECIAL_MUSIC=1)
+                includeIfStandard "data\stats\allies\allybattlescenemusics-standard.asm"	; Per-character battlescene music override
+            endif
                 includeIfStandard "code\gameflow\battle\battlefunctions\executeindividualturn-standard.asm"
                 includeIfStandard "code\gameflow\battle\battlefunctions\setmovesfx-standard.asm"
                 includeIfStandard "code\gameflow\battle\battlefunctions\resetaijaro-standard.asm"

--- a/disasm/layout/sf2-05-0x020000-0x028000.asm
+++ b/disasm/layout/sf2-05-0x020000-0x028000.asm
@@ -50,6 +50,10 @@
             if (ENABLE_ALLY_SPECIAL_MUSIC=1)
                 includeIfStandard "data\stats\allies\allybattlescenemusics-standard.asm"	; Per-character battlescene music override
             endif
+			if (ENABLE_UNINTERRUPTIBLE_MUSIC=1)
+				includeIfStandard "data\uninterruptiblemusics-standard.asm"
+                alignIfStandard
+			endif
                 includeIfStandard "code\gameflow\battle\battlefunctions\executeindividualturn-standard.asm"
                 includeIfStandard "code\gameflow\battle\battlefunctions\setmovesfx-standard.asm"
                 includeIfStandard "code\gameflow\battle\battlefunctions\resetaijaro-standard.asm"

--- a/disasm/sf2patches.asm
+++ b/disasm/sf2patches.asm
@@ -121,6 +121,7 @@ ENABLE_ALLY_SUPPORT_MUSIC:			equ 0		; Enable specific battlescene music to play 
 ENABLE_ALLY_SPELL_MUSIC:			equ 0		; Enable specific battlescene music to play when ally unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
 ENABLE_ENEMY_SUPPORT_MUSIC:			equ 0		; Enable specific battlescene music to play when enemy unit uses a spell/item on self or other enemy units (e.g: healing and buff spells), doesn't apply if affected by Muddle
 ENABLE_ENEMY_SPELL_MUSIC:			equ 0		; Enable specific battlescene music to play when enemy unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
+ENABLE_UNINTERRUPTIBLE_MUSIC:		equ 0       ; Keep playing battle map music in battlescenes if the battle map music is present in 'uninterruptiblemusics-standard.asm' list
 
 
 ; Support/spell patch music selector (note: this patch works best if you add new custom musics)

--- a/disasm/sf2patches.asm
+++ b/disasm/sf2patches.asm
@@ -116,11 +116,11 @@ TRAP_DAMAGE_RAISES_WITH_DIFFICULTY: equ 0       ; Increase Laser/Burst Rock dama
 
 
 ; Music features
-ENABLE_ALLY_SPECIAL_MUSIC:			equ 1		; Enable specific battlescene music to play for specific characters (behave like boss music, but doesn't play when using items), defined in 'allybattlescenemusics-standard.asm' file, has highest priority
-ENABLE_ALLY_SUPPORT_MUSIC:			equ 1		; Enable specific battlescene music to play when ally unit uses a spell/item on self or other ally units (e.g: healing and buff spells), doesn't apply if affected by Muddle
-ENABLE_ALLY_SPELL_MUSIC:			equ 1		; Enable specific battlescene music to play when ally unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
-ENABLE_ENEMY_SUPPORT_MUSIC:			equ 1		; Enable specific battlescene music to play when enemy unit uses a spell/item on self or other enemy units (e.g: healing and buff spells), doesn't apply if affected by Muddle
-ENABLE_ENEMY_SPELL_MUSIC:			equ 1		; Enable specific battlescene music to play when enemy unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
+ENABLE_ALLY_SPECIAL_MUSIC:			equ 0		; Enable specific battlescene music to play for specific characters (behave like boss music, but doesn't play when using items), defined in 'allybattlescenemusics-standard.asm' file, has highest priority
+ENABLE_ALLY_SUPPORT_MUSIC:			equ 0		; Enable specific battlescene music to play when ally unit uses a spell/item on self or other ally units (e.g: healing and buff spells), doesn't apply if affected by Muddle
+ENABLE_ALLY_SPELL_MUSIC:			equ 0		; Enable specific battlescene music to play when ally unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
+ENABLE_ENEMY_SUPPORT_MUSIC:			equ 0		; Enable specific battlescene music to play when enemy unit uses a spell/item on self or other enemy units (e.g: healing and buff spells), doesn't apply if affected by Muddle
+ENABLE_ENEMY_SPELL_MUSIC:			equ 0		; Enable specific battlescene music to play when enemy unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
 
 
 ; Support/spell patch music selector (note: this patch works best if you add new custom musics)

--- a/disasm/sf2patches.asm
+++ b/disasm/sf2patches.asm
@@ -115,6 +115,8 @@ TRADEABLE_ITEMS:                    equ 0       ; Allow trading items in battle 
 TRAP_DAMAGE_RAISES_WITH_DIFFICULTY: equ 0       ; Increase Laser/Burst Rock damage with difficulty.   Normal:100%  Hard:125%  Super: 150%  Ouch: 175%
 ENABLE_ALLY_SUPPORT_MUSIC:			equ 0		; Enable specific battlescene music to play when ally unit uses a spell/item on self or other ally units (e.g: healing and buff spells), doesn't apply if affected by Muddle
 ENABLE_ALLY_SPELL_MUSIC:			equ 0		; Enable specific battlescene music to play when ally unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
+ENABLE_ENEMY_SUPPORT_MUSIC:			equ 0		; Enable specific battlescene music to play when enemy unit uses a spell/item on self or other enemy units (e.g: healing and buff spells), doesn't apply if affected by Muddle
+ENABLE_ENEMY_SPELL_MUSIC:			equ 0		; Enable specific battlescene music to play when enemy unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
 
 
 ; Support/spell patch music selector (note: this patch works best if you add new custom musics)
@@ -122,6 +124,8 @@ ALLY_SUPPORT_MUSIC:   				equ MUSIC_SHRINE		; Requires ENABLE_ALLY_SUPPORT_MUSIC
 ALLY_SUPPORT_PROMOTED_MUSIC:   		equ MUSIC_ELVEN_TOWN	; Requires ENABLE_ALLY_SUPPORT_MUSIC patch to be enabled
 ALLY_SPELL_MUSIC:   				equ MUSIC_WITCH			; Requires ENABLE_ALLY_SPELL_MUSIC patch to be enabled
 ALLY_SPELL_PROMOTED_MUSIC:   		equ MUSIC_INTRO			; Requires ENABLE_ALLY_SPELL_MUSIC patch to be enabled
+ENEMY_SUPPORT_MUSIC:   				equ MUSIC_SUSPEND		; Requires ENABLE_ENEMY_SUPPORT_MUSIC patch to be enabled
+ENEMY_SPELL_MUSIC:   				equ MUSIC_BOSS_ATTACK	; Requires ENABLE_ENEMY_SPELL_MUSIC patch to be enabled
 
 
 ; Special screens

--- a/disasm/sf2patches.asm
+++ b/disasm/sf2patches.asm
@@ -179,15 +179,8 @@ SECOND_MEMBERS_LIST_PAGE: equ secondMembersListPage
 
 
 ; Sound driver
-MUSIC_RESUMING:                     equ 1       ; 
-RESUME_BATTLEFIELD_MUSIC_ONLY:      equ 1       ; Do not resume battlescene music.
+MUSIC_RESUMING:                     equ 1       ; Enable music resuming (musics only resume in battlescenes if they are added to 'resumingbattlescenemusics-standard.asm' list)
 RESUME_MUSIC_AFTER_JOIN_JINGLE:     equ 1       ; Resume background music after playing a "Joined the Force" jingle.
-
-resumeBattlesceneMusic = 1
-    if (RESUME_BATTLEFIELD_MUSIC_ONLY=1)
-resumeBattlesceneMusic = 0
-    endif
-RESUME_BATTLESCENE_MUSIC: equ resumeBattlesceneMusic
 
 
 ; Data expansions

--- a/disasm/sf2patches.asm
+++ b/disasm/sf2patches.asm
@@ -113,10 +113,14 @@ SEND_DROPPED_ITEMS_TO_CARAVAN:      equ 1       ; If character inventory is full
 SPELLS_REFRESH_STATUS_COUNTERS:     equ 1       ; Boost, Slow, and Attack spells refresh status counters instead of failing, as long as the counter is increased by at least 1. Battle messages display the actual regained stats values.
 TRADEABLE_ITEMS:                    equ 0       ; Allow trading items in battle without full inventory.
 TRAP_DAMAGE_RAISES_WITH_DIFFICULTY: equ 0       ; Increase Laser/Burst Rock damage with difficulty.   Normal:100%  Hard:125%  Super: 150%  Ouch: 175%
-ENABLE_ALLY_SUPPORT_MUSIC:			equ 0		; Enable specific battlescene music to play when ally unit uses a spell/item on self or other ally units (e.g: healing and buff spells), doesn't apply if affected by Muddle
-ENABLE_ALLY_SPELL_MUSIC:			equ 0		; Enable specific battlescene music to play when ally unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
-ENABLE_ENEMY_SUPPORT_MUSIC:			equ 0		; Enable specific battlescene music to play when enemy unit uses a spell/item on self or other enemy units (e.g: healing and buff spells), doesn't apply if affected by Muddle
-ENABLE_ENEMY_SPELL_MUSIC:			equ 0		; Enable specific battlescene music to play when enemy unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
+
+
+; Music features
+ENABLE_ALLY_SPECIAL_MUSIC:			equ 1		; Enable specific battlescene music to play for specific characters (behave like boss music, but doesn't play when using items), defined in 'allybattlescenemusics-standard.asm' file, has highest priority
+ENABLE_ALLY_SUPPORT_MUSIC:			equ 1		; Enable specific battlescene music to play when ally unit uses a spell/item on self or other ally units (e.g: healing and buff spells), doesn't apply if affected by Muddle
+ENABLE_ALLY_SPELL_MUSIC:			equ 1		; Enable specific battlescene music to play when ally unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
+ENABLE_ENEMY_SUPPORT_MUSIC:			equ 1		; Enable specific battlescene music to play when enemy unit uses a spell/item on self or other enemy units (e.g: healing and buff spells), doesn't apply if affected by Muddle
+ENABLE_ENEMY_SPELL_MUSIC:			equ 1		; Enable specific battlescene music to play when enemy unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
 
 
 ; Support/spell patch music selector (note: this patch works best if you add new custom musics)

--- a/disasm/sf2patches.asm
+++ b/disasm/sf2patches.asm
@@ -113,8 +113,8 @@ SEND_DROPPED_ITEMS_TO_CARAVAN:      equ 1       ; If character inventory is full
 SPELLS_REFRESH_STATUS_COUNTERS:     equ 1       ; Boost, Slow, and Attack spells refresh status counters instead of failing, as long as the counter is increased by at least 1. Battle messages display the actual regained stats values.
 TRADEABLE_ITEMS:                    equ 0       ; Allow trading items in battle without full inventory.
 TRAP_DAMAGE_RAISES_WITH_DIFFICULTY: equ 0       ; Increase Laser/Burst Rock damage with difficulty.   Normal:100%  Hard:125%  Super: 150%  Ouch: 175%
-ENABLE_ALLY_SUPPORT_MUSIC:			equ 1		; Enable specific battlescene music to play when ally unit uses a spell/item on self or other ally units (e.g: healing and buff spells), doesn't apply if affected by Muddle
-ENABLE_ALLY_SPELL_MUSIC:			equ 1		; Enable specific battlescene music to play when ally unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
+ENABLE_ALLY_SUPPORT_MUSIC:			equ 0		; Enable specific battlescene music to play when ally unit uses a spell/item on self or other ally units (e.g: healing and buff spells), doesn't apply if affected by Muddle
+ENABLE_ALLY_SPELL_MUSIC:			equ 0		; Enable specific battlescene music to play when ally unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
 
 
 ; Support/spell patch music selector (note: this patch works best if you add new custom musics)

--- a/disasm/sf2patches.asm
+++ b/disasm/sf2patches.asm
@@ -113,6 +113,15 @@ SEND_DROPPED_ITEMS_TO_CARAVAN:      equ 1       ; If character inventory is full
 SPELLS_REFRESH_STATUS_COUNTERS:     equ 1       ; Boost, Slow, and Attack spells refresh status counters instead of failing, as long as the counter is increased by at least 1. Battle messages display the actual regained stats values.
 TRADEABLE_ITEMS:                    equ 0       ; Allow trading items in battle without full inventory.
 TRAP_DAMAGE_RAISES_WITH_DIFFICULTY: equ 0       ; Increase Laser/Burst Rock damage with difficulty.   Normal:100%  Hard:125%  Super: 150%  Ouch: 175%
+ENABLE_ALLY_SUPPORT_MUSIC:			equ 1		; Enable specific battlescene music to play when ally unit uses a spell/item on self or other ally units (e.g: healing and buff spells), doesn't apply if affected by Muddle
+ENABLE_ALLY_SPELL_MUSIC:			equ 1		; Enable specific battlescene music to play when ally unit uses a spell/item (restricted to damage and debuff spells if support music patch is also enabled)
+
+
+; Support/spell patch music selector (note: this patch works best if you add new custom musics)
+ALLY_SUPPORT_MUSIC:   				equ MUSIC_SHRINE		; Requires ENABLE_ALLY_SUPPORT_MUSIC patch to be enabled
+ALLY_SUPPORT_PROMOTED_MUSIC:   		equ MUSIC_ELVEN_TOWN	; Requires ENABLE_ALLY_SUPPORT_MUSIC patch to be enabled
+ALLY_SPELL_MUSIC:   				equ MUSIC_WITCH			; Requires ENABLE_ALLY_SPELL_MUSIC patch to be enabled
+ALLY_SPELL_PROMOTED_MUSIC:   		equ MUSIC_INTRO			; Requires ENABLE_ALLY_SPELL_MUSIC patch to be enabled
 
 
 ; Special screens


### PR DESCRIPTION
(the PR was remade as the original one had an incorrect branch name)

## 🎯 Purpose of This PR

Here is my first contribution to the list of patches available to make SF2 fan projects.

The purpose of this patch is to allow the creator to replace the battlescene music that plays under various conditions described below.

When a Force member casts a spell/item:
- "Support" music plays when no monster is in target list and the Force member is not under the effect of Muddle. This effectively restricts the "Support" music to healing and buff spells/items.
- "Spell" music plays when the Force member uses a spell or an item, including Kiwi breath spell. This is evaluated AFTER the "Support" music check when both patches are enabled.

"Support" and "Spell" music patches can be enabled separately from each other.
The creator can specify in sf2patches.asm which music should be played for "Support" and "Spell".
It is expected that the creator expands the music list enum so that this features makes sense with brand new musics imported in the soundbank.

UPDATE 1: this patch has been extended to also include a similar feature for enemy monsters.

UPDATE 2: this patch has been extended to allow the creator to assign a character-specific special music to Force members when they attack or cast spells (but not use items).

UPDATE 3: "RESUME_BATTLEFIELD_MUSIC_ONLY" patch toggle has been removed and replaced by a table where the creator can list which battlescene musics have resuming enabled (resumingbattlescenemusics-standard.asm).

UPDATE 4: added "ENABLE_UNINTERRUPTIBLE_MUSIC" patch toggle to have the battle map music keep playing during battlescenes, only if the battle map music has been listed in 'uninterruptiblemusics-standard.asm' file.

Phew I'm beat! I think I won't touch ASM for a while now and I consider this feature branch final.
I think with all of these, the creator will have absolute control over the battlescene music behavior.

## 🔗 Related Discussion or Issue

N/A

## 🧩 Summary of Changes

- Updated ASM routine: LoadBattlesceneMusicIndex (new battlescene music selection logic)
- Updated ASM routine: InitializeBattlescene (new battlescene music resuming logic)
- Added relevant config items in sf2patches.asm
- Added allybattlescenemusics-standard.asm where the game designer can assign specific musics to Force members
- Added resumingbattlescenemusics-standard.asm where the creator specifies which battlescene musics have resuming enabled
- Added uninterruptiblemusics-standard.asm to list musics that should keep playing during battlescenes, and modified battlescene logic to remove when needed: enter fade-out, enter play command, exit fade-out

## 🔄 Coordination Notes

N/A

## 🧪 How Has This Been Tested?

- [x] Run build.bat and confirm that it produces a bit-perfect replica of original rom
- [x] Run buildstandard.bat or buildexpanded.bat, if applicable, and confirm that build succeeds
- [x] Play Prism battle with monster control enabled, apply Muddle on Force members spellcasters, and verify the "Support" and "Spell" musics get triggered in the various possible combinations. When a Force member affected by Muddle casts a spell against other Force members, the "Support" music is NOT played and the "Spell" music plays instead.
- [x] Same as above, but for monsters
- [x] Play Ancient Shrine battle with unpromoted Bowie, verify that the unpromoted version of "Support" and "Spell" musics get triggered
- [x] Verify that special music assigned to Force members play when they attack/cast spells, but not when using items
- [x] Verify that battlescene music correctly resumes when it is present in "table_ResumingBattlesceneMusics" when triggering consecutive battlescenes with the same music.
- [x] Verify that battle map keeps playing during battlescenes if it's present in "table_UninterruptibleMusics". Also verified that this feature works properly for maps that change their music during battle (for example the Castle battle during early game).

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## 📚 Additional Notes

Hello SF2 community, glad to be able to give something back, after enjoying the creations from existing members ;-)
I work in software development IRL, using mainly C# (which pretty means I never, ever write ASM code).

I hope to finish soon my SF2 Music Cooker tool to allow the community to import custom musics in the game, which should make this feature PR pretty useful!